### PR TITLE
use specific EBiSC URLs on hPSCreg

### DIFF
--- a/tracker/lib/EBiSC/API/hPSCreg.pm
+++ b/tracker/lib/EBiSC/API/hPSCreg.pm
@@ -32,7 +32,7 @@ sub _build_base_url {
 
 sub _full_list {
   my ($self, %options) = @_;
-  my $url = sprintf('%s%s', $self->base_url, $options{url}||"/api/full_list");
+  my $url = sprintf('%s%s', $self->base_url, $options{url}||"/api/export/ebisc");
   my $response = $self->ua->get($url);
   die $response->status_line if $response->is_error;
   my $content = eval{decode_json($response->content);};
@@ -50,7 +50,7 @@ sub _build_cursor {
 
 sub get_line {
   my ($self, $line_name) = @_;
-  my $url = sprintf('%s/api/export/%s', $self->base_url, $line_name);
+  my $url = sprintf('%s/api/export/ebisc/%s', $self->base_url, $line_name);
   my $response = $self->ua->get($url);
   die $response->status_line if $response->is_error;
   my $content = eval{decode_json($response->content);};


### PR DESCRIPTION
The old ones might change content later,
while the specific EBiSC ones try to be
backwards compatible longer.

The new endpoints are
hpscreg.eu/api/export/ebisc (full list)
hpscreg.eu/api/export/ebisc/{id/name}